### PR TITLE
Address CRAN compilation note (closes #49)

### DIFF
--- a/src/CO_AutoCorr.c
+++ b/src/CO_AutoCorr.c
@@ -373,7 +373,8 @@ double CO_trev_1_num(const double y[], const int size)
 
     int tau = 1;
 
-    double * diffTemp = malloc((size-1) * sizeof * diffTemp);
+    const int allocsize = (size-1) * sizeof(double);
+    double * diffTemp = malloc(allocsize);
 
     for(int i = 0; i < size-tau; i++)
     {
@@ -407,8 +408,9 @@ double CO_HistogramAMI_even_2_5(const double y[], const int size)
     //const int tau = 2;
     //const int numBins = 5;
 
-    double * y1 = malloc((size-tau) * sizeof(double));
-    double * y2 = malloc((size-tau) * sizeof(double));
+    const int allocsize = (size-tau) * sizeof(double);
+    double * y1 = malloc(allocsize);
+    double * y2 = malloc(allocsize);
 
     for(int i = 0; i < size-tau; i++){
         y1[i] = y[i];

--- a/src/MD_hrv.c
+++ b/src/MD_hrv.c
@@ -23,7 +23,8 @@ double MD_hrv_classic_pnn40(const double y[], const int size){
     const int pNNx = 40;
     
     // compute diff
-    double * Dy = malloc((size-1) * sizeof(double));
+    const int allocsize = (size-1) * sizeof(double);
+    double * Dy = malloc(allocsize);
     diff(y, size, Dy);
     
     double pnn40 = 0;

--- a/src/SB_BinaryStats.c
+++ b/src/SB_BinaryStats.c
@@ -21,7 +21,8 @@ double SB_BinaryStats_diff_longstretch0(const double y[], const int size){
     }
 
     // binarize
-    int * yBin = malloc((size-1) * sizeof(int));
+    const int allocsize = (size-1) * sizeof(double);
+    int * yBin = malloc(allocsize);
     for(int i = 0; i < size-1; i++){
 
         double diffTemp = y[i+1] - y[i];
@@ -63,7 +64,8 @@ double SB_BinaryStats_mean_longstretch1(const double y[], const int size){
     }
 
     // binarize
-    int * yBin = malloc((size-1) * sizeof(int));
+    const int allocsize = (size-1) * sizeof(double);
+    int * yBin = malloc(allocsize);
     double yMean = mean(y, size);
     for(int i = 0; i < size-1; i++){
 

--- a/src/SB_MotifThree.c
+++ b/src/SB_MotifThree.c
@@ -201,7 +201,7 @@ double * sb_motifthree(const double y[], int size, const char how[])
     // from yt
     for (i = 0; i < alphabet_size; i++) {
         if (sizes_r1[i] != 0 && r1[i][sizes_r1[i] - 1] == size - 1) {
-            tmp_ar = malloc((sizes_r1[i] - 1) * sizeof(tmp_ar));
+            tmp_ar = calloc((sizes_r1[i] - 1), sizeof(tmp_ar));
             subset(r1[i], tmp_ar, 0, sizes_r1[i]);
             memcpy(r1[i], tmp_ar, (sizes_r1[i] - 1) * sizeof(tmp_ar));
             sizes_r1[i]--;


### PR DESCRIPTION
Original issue reproduced with g++-14 on Ubuntu 24.04, changes address it. Also suppresses one of two remaining 'possibly uninitialized' warnings.